### PR TITLE
Remove `--quite` flag and extract cloud test run URL

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29897,8 +29897,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const glob = __importStar(__nccwpck_require__(8090));
-const fs = __importStar(__nccwpck_require__(5630));
 const child_process_1 = __nccwpck_require__(2081);
+const fs = __importStar(__nccwpck_require__(5630));
 var TEST_PIDS = [];
 run();
 /**
@@ -29990,7 +29990,7 @@ async function run() {
         function generateCommand(path) {
             const args = [
                 // `--address=""`, // Disable the REST API. THIS DOESN'T WORK???? TODO: Investigate
-                '--quiet',
+                // '--quiet',
                 ...(flags ? flags.split(' ') : []),
             ];
             if (isCloud && cloudRunLocally) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import * as core from '@actions/core'
-import * as glob from '@actions/glob'
-import * as fs from 'fs-extra'
-import { spawn } from 'child_process'
+import * as core from '@actions/core';
+import * as glob from '@actions/glob';
+import { spawn } from 'child_process';
+import * as fs from 'fs-extra';
 
 var TEST_PIDS: number[] = [];
 
@@ -98,7 +98,7 @@ export async function run(): Promise<void> {
         function generateCommand(path: string): string {
             const args = [
                 // `--address=""`, // Disable the REST API. THIS DOESN'T WORK???? TODO: Investigate
-                '--quiet',
+                // '--quiet',
                 ...(flags ? flags.split(' ') : []),
             ]
             if (isCloud && cloudRunLocally) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ export async function run(): Promise<void> {
             });
             // Parse k6 command output and extract test run URLs if running in cloud mode. 
             // Also, print the output to the console, excluding the progress lines.
-            child.stdout?.on('data', (data) => parseK6Output(data, isCloud ? TEST_RESULT_URLS_MAP : null, TOTAL_TEST_RUNS));  
+            child.stdout?.on('data', (data) => parseK6Output(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS));  
             
             return child;
         }

--- a/src/k6OutputParser.ts
+++ b/src/k6OutputParser.ts
@@ -1,0 +1,71 @@
+import { TestResultUrlsMap } from './types';
+
+const REGEX_EXPRESSIONS = {
+    scriptPath: /^\s*script:\s*(.+)$/m,
+    output: /^\s*output:\s*(.+)$/m,
+    runningIteration: /running \(.*\), \d+\/\d+ VUs, \d+ complete and \d+ interrupted iterations/g,
+    runProgress: /\[ *(\d+)% *\] *\d+ VUs/g
+};
+
+
+function extractTestRunUrl(data: string, testResultUrlsMap: TestResultUrlsMap): void {
+    /**
+     * This function extracts the script path and output URL from the k6 output.
+     * It then adds the script path and output URL to the testResultUrlsMap which is a reference to 
+     * an object passed from the main function to store test run urls mapped to corresponding test script.
+     * 
+     * @param {string} data - The k6 command output data as string
+     * @param {TestResultUrlsMap} testResultUrlsMap - The map containing the script path and output URL
+     * 
+     * @returns {void}
+     * 
+     */
+
+    // Extracting the script path
+    const scriptMatch = data.match(REGEX_EXPRESSIONS.scriptPath);
+    const scriptPath = scriptMatch ? scriptMatch[1] : null;
+
+    // Extracting the output URL
+    const outputMatch = data.match(REGEX_EXPRESSIONS.output);
+    const output = outputMatch ? outputMatch[1] : null;
+
+    if (scriptPath && output) {
+        testResultUrlsMap[scriptPath] = output;
+    }
+}
+
+
+export function parseK6Output(data: Buffer, testResultUrlsMap: TestResultUrlsMap | null, totalTestRuns: number): void {
+    /*
+    * This function is responsible for parsing the output of the k6 command. 
+    * It filters out the progress lines and logs the rest of the output.
+    * It also extracts the test run URLs from the output.
+    * 
+    * @param {Buffer} data - The k6 command output data
+    * @param {TestResultUrlsMap | null} testResultUrlsMap - The map containing the script path and output URL. If null, the function will not extract test run URLs.
+    * @param {number} totalTestRuns - The total number of test runs. This is used to determine when all test run URLs have been extracted.
+    * 
+    * @returns {void}
+    */ 
+
+    const dataString = data.toString(),
+        lines = dataString.split('\n');
+    
+    // Extract test run URLs
+    if (testResultUrlsMap && Object.keys(testResultUrlsMap).length < totalTestRuns) {
+        extractTestRunUrl(dataString, testResultUrlsMap);
+    }
+
+    const filteredLines = lines.filter((line) => {
+        const isRegexMatch = REGEX_EXPRESSIONS.runningIteration.test(line) || REGEX_EXPRESSIONS.runProgress.test(line);
+        return !isRegexMatch;
+    });
+
+    if (filteredLines.length < lines.length) {
+        // ignore empty lines only when progress lines output was ignored.
+        if (filteredLines.join("") === "") {
+            return;
+        }
+    }
+    console.log(filteredLines.join('\n'))
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export type TestResultUrlsMap = {
+    [key: string]: string;
+};


### PR DESCRIPTION
Ticket - https://github.com/grafana/k6-cloud/issues/2234

This is a pre-requisite for adding functionality for commenting a link to the cloud test run URL. 

Here, we remove the `--quite` flag from the run command and parse the k6 command output to extract the cloud run URL. We also ignore the test progress output to prevent the shell from getting polluted with multiple log lines of progress updates. 

