### PR TITLE
[feat] Validate test paths before executing test run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Grafana k6
-      uses: grafana/setup-k6-action@v0.0.1
+      uses: grafana/setup-k6-action@main
       with:
         k6-version: '0.49.0'
     - uses: ./
@@ -22,3 +22,20 @@ jobs:
         flags: --vus 10 --duration 30s
         parallel: true
         cloud-run-locally: false
+  verify-scripts:
+    runs-on: ubuntu-latest
+    env:
+      K6_CLOUD_TOKEN: ${{ secrets.K6_CLOUD_TOKEN }}
+      K6_CLOUD_PROJECT_ID:  ${{ secrets.K6_CLOUD_PROJECT_ID }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: grafana/setup-k6-action@main
+      with:
+        k6-version: '0.49.0'
+    - uses: ./
+      continue-on-error: true
+      with:
+        path: |
+          ./dev/verify-script-tests/**.js
+        only-verify-scripts: true

--- a/action.yaml
+++ b/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: 'If true, comment the cloud test run URL on the pull request'
     default: "true"
     required: false
+  only-verify-scripts: 
+    description: 'If true, only check if the test scripts are valid and skip test execution'
+    default: "false"
+    required: false
 
 runs:
   using: node20

--- a/dev/verify-script-tests/invalid-test.js
+++ b/dev/verify-script-tests/invalid-test.js
@@ -1,0 +1,15 @@
+import { sleep } from "k6";
+import http from "k6/http";
+
+export const options = {
+  scenarios: {
+    createBrowser: {
+      executor: "constant-arrival-rate",
+    },
+  },
+};
+
+export default function () {
+  http.get("http://test.k6.io");
+  sleep(1);
+}

--- a/dev/verify-script-tests/no-test.js
+++ b/dev/verify-script-tests/no-test.js
@@ -1,0 +1,2 @@
+// Sample JS file with no tests
+console.log("No tests in this file");

--- a/dev/verify-script-tests/valid-test.js
+++ b/dev/verify-script-tests/valid-test.js
@@ -1,0 +1,7 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export default function () {
+  http.get('http://test.k6.io');
+  sleep(1);
+}

--- a/src/k6helper.ts
+++ b/src/k6helper.ts
@@ -1,0 +1,47 @@
+// Common helper functions used in the action 
+import { spawn } from 'child_process';
+
+export async function validateTestPaths(testPaths: string[]): Promise<string[]> {
+    /**
+     * Validates the test paths by running `k6 inspect --execution-requirements` on each test file.
+     * A test path is considered valid if the command returns an exit code of 0.
+     *
+     * @export
+     * @param {string[]} testPaths - List of test paths to validate
+     * @return {Promise<string[]>} - List of valid test paths
+     */
+
+    if (testPaths.length === 0) {
+        throw new Error('No test files found')
+    }
+
+    console.log(`🔍 Validating test run files.`);
+
+    const validK6TestPaths: string[] = [],
+        command = "k6",
+        defaultArgs = ["inspect", "--execution-requirements"];
+
+    const allPromises = [] as any[];
+
+    testPaths.forEach(async testPath => {
+        const args = [...defaultArgs, testPath];
+
+        const child = spawn(command, args, {
+            stdio: ['inherit', 'ignore', 'inherit'], // 'ignore' is for stdout
+            detached: false,
+        });
+
+        allPromises.push(new Promise<void>(resolve => {
+            child.on('exit', (code: number, signal: string) => {
+                if (code === 0) {
+                    validK6TestPaths.push(testPath);
+                }
+                resolve();
+            });
+        }));
+    });
+
+    await Promise.all(allPromises);
+
+    return validK6TestPaths;
+}


### PR DESCRIPTION
Fixes #4 

- Uses `k6 inspect` to only continue executing tests for valid k6 scripts and ignore other ones. 
- Add new action input to allow only validating tests scripts without executing them as requested in this [old issue.](https://github.com/grafana/k6-action/issues/13)