### PR TITLE
Fix cloud-run-locally input behaviour and action failing without flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,19 @@ jobs:
         flags: --vus 10 --duration 30s
         parallel: true
         cloud-run-locally: false
+  protocol-without-flags:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: grafana/setup-k6-action@main
+      with:
+        k6-version: '0.49.0'
+    - uses: ./
+      continue-on-error: true
+      with:
+        path: |
+          ./dev/protocol*.js
   verify-scripts:
     runs-on: ubuntu-latest
     env:

--- a/action.yaml
+++ b/action.yaml
@@ -24,12 +24,13 @@ inputs:
     required: false
   cloud-run-locally:
     description: 'If true, run tests locally instead and upload results to Grafana Cloud k6'
+    default: "true"
     required: false
   cloud-comment-on-pr:
     description: 'If true, comment the cloud test run URL on the pull request'
     default: "true"
     required: false
-  only-verify-scripts: 
+  only-verify-scripts:
     description: 'If true, only check if the test scripts are valid and skip test execution'
     default: "false"
     required: false


### PR DESCRIPTION
- Fixes the behaviour of `cloud-run-locally` action input where it was behaving opposite to what was expected
- Fixes a bug where if no flags are sent as input the action crashes with error code 255

Fixes #15
Fixed #14