### PR TITLE
Add new input to show all k6 command output

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup Grafana k6
       uses: grafana/setup-k6-action@main
-      with:
-        k6-version: '0.49.0'
     - uses: ./
       continue-on-error: true
       with:
@@ -28,24 +26,29 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup Grafana k6
       uses: grafana/setup-k6-action@main
-      with:
-        k6-version: '0.49.0'
     - uses: ./
       continue-on-error: true
       with:
         path: |
           ./dev/protocol*.js
-  verify-scripts:
+  show-complete-k6-output:
     runs-on: ubuntu-latest
-    env:
-      K6_CLOUD_TOKEN: ${{ secrets.K6_CLOUD_TOKEN }}
-      K6_CLOUD_PROJECT_ID:  ${{ secrets.K6_CLOUD_PROJECT_ID }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Grafana k6
       uses: grafana/setup-k6-action@main
+    - uses: ./
       with:
-        k6-version: '0.49.0'
+        path: |
+          ./dev/protocol.js
+        flags: --vus 10 --duration 30s
+        show-k6-progress-output: true
+  verify-scripts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: grafana/setup-k6-action@main
     - uses: ./
       continue-on-error: true
       with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  
+
   <img
     src="./images/k6.gif"
     width="600"
@@ -12,7 +12,7 @@
 
 # run-k6-action
 
-This action allows you to easily execute k6 tests as part of your GitHub Actions workflow. 
+This action allows you to easily execute k6 tests as part of your GitHub Actions workflow.
 
 It is a wrapper over `k6 run`, with support for globs, parallel execution, fail-fast, and many other features.
 
@@ -22,19 +22,19 @@ It is a wrapper over `k6 run`, with support for globs, parallel execution, fail-
 
 The following inputs can be used as `step.with` key:
 
-| Name | Type | Required | Default | Description 
-| --- | --- | --- | --- | --- |
-| `path` | string | `true` | `''` | Glob pattern to select one or multiple test scripts to run. <br/> e.g. `./tests/api*.js` <br/> One can also supply multiple patterns by separating them with new line.<br/><code>path: \|<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./tests/api*.js<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./tests/app*.js</code>
-| `cloud-run-locally` | boolean | `false` | `true` | If `true`, the tests are executed locally and the results are uploaded to Grafana Cloud k6
-| `parallel` | boolean | `false` | `false` | If `true` and multiple tests are executed, all them run in parallel. 
-| `fail-fast` | boolean | `false` | `false` | If `true`, the whole pipeline fails as soon as the first test fails 
-| `flags` | string | `false` | `''` | Additional flags to be passed on to the `k6 run` command.<br/>e.g. `--vus 10 --duration 20s`
-| `cloud-comment-on-pr` | boolean | `false` | `true` | If `true`, the workflow comments a link to the cloud test run on the pull request (if present)
-| `only-verify-scripts` | boolean | `false` | `false` | If `true`, only check if the test scripts are valid and skip the test execution'
-
+| Name                      | Type    | Required | Default | Description                                                                                                                                                                                                                                                                                          |
+| ------------------------- | ------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`                    | string  | `true`   | `''`    | Glob pattern to select one or multiple test scripts to run. <br/> e.g. `./tests/api*.js` <br/> One can also supply multiple patterns by separating them with new line.<br/><code>path: \|<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./tests/api*.js<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./tests/app*.js</code> |
+| `cloud-run-locally`       | boolean | `false`  | `true`  | If `true`, the tests are executed locally and the results are uploaded to Grafana Cloud k6                                                                                                                                                                                                           |
+| `parallel`                | boolean | `false`  | `false` | If `true` and multiple tests are executed, all them run in parallel.                                                                                                                                                                                                                                 |
+| `fail-fast`               | boolean | `false`  | `false` | If `true`, the whole pipeline fails as soon as the first test fails                                                                                                                                                                                                                                  |
+| `flags`                   | string  | `false`  | `''`    | Additional flags to be passed on to the `k6 run` command.<br/>e.g. `--vus 10 --duration 20s`                                                                                                                                                                                                         |
+| `cloud-comment-on-pr`     | boolean | `false`  | `true`  | If `true`, the workflow comments a link to the cloud test run on the pull request (if present)                                                                                                                                                                                                       |
+| `only-verify-scripts`     | boolean | `false`  | `false` | If `true`, only check if the test scripts are valid and skip the test execution                                                                                                                                                                                                                      |
+| `show-k6-progress-output` | boolean | `false`  | `false` | If true, the output from k6 will be shown in the action logs, else only the summary will be shown.                                                                                                                                                                                                   |
 ## Usage
 
-Following are some examples of using the workflow. 
+Following are some examples of using the workflow.
 
 ### Basic
 
@@ -113,7 +113,7 @@ jobs:
           fail-fast: false # optional: fail the step early if any test fails (default: true)
 ```
 
-Comment Grafana cloud k6 test URL on PR 
+Comment Grafana cloud k6 test URL on PR
 
 ```yaml
 - uses: grafana/run-k6-action@v1

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,10 @@ inputs:
     description: 'If true, only check if the test scripts are valid and skip test execution'
     default: "false"
     required: false
+  show-k6-progress-output:
+    description: 'If true, the output from k6 will be shown in the action logs, else only the summary will be shown'
+    default: "false"
+    required: false
 
 runs:
   using: node20

--- a/dist/index.js
+++ b/dist/index.js
@@ -34364,7 +34364,9 @@ async function run() {
         const cloudRunLocally = core.getInput('cloud-run-locally', { required: false }) === 'true';
         const onlyVerifyScripts = core.getInput('only-verify-scripts', { required: false }) === 'true';
         const shouldCommentCloudTestRunUrlOnPR = core.getInput('cloud-comment-on-pr', { required: false }) === 'true';
+        const showK6ProgressOutput = core.getInput('show-k6-progress-output', { required: false }) === 'true';
         const allPromises = [];
+        core.debug(`Flag to show k6 progress output set to: ${showK6ProgressOutput}`);
         core.debug(`🔍 Found following ${testPaths.length} test run files:`);
         testPaths.forEach((testPath, index) => {
             core.debug(`${index + 1}. ${testPath}`);
@@ -34405,7 +34407,6 @@ async function run() {
                 return true;
             }
         });
-        ;
         let allTestsPassed = true;
         if (parallel) {
             const childProcesses = [];
@@ -34516,7 +34517,7 @@ async function run() {
             });
             // Parse k6 command output and extract test run URLs if running in cloud mode.
             // Also, print the output to the console, excluding the progress lines.
-            child.stdout?.on('data', (data) => (0, k6OutputParser_1.parseK6Output)(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS));
+            child.stdout?.on('data', (data) => (0, k6OutputParser_1.parseK6Output)(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS, showK6ProgressOutput));
             return child;
         }
     }
@@ -34579,7 +34580,7 @@ const REGEX_EXPRESSIONS = {
     output: /^\s*output:\s*(.+)$/m,
     outputCloudUrl: /cloud\s*\((.+)\)/,
     runningIteration: /running \(.*\), \d+\/\d+ VUs, \d+ complete and \d+ interrupted iterations/g,
-    //  default   [  20% ] 10 VUs  1.0s/5s  
+    //  default   [  20% ] 10 VUs  1.0s/5s
     // createBrowser   [  61% ] 035/500 VUs  0m36.5s/1m0s  5.00 iters/s
     executionProgress: /\[\s*(\d+)%\s*\]\s*\d+(\/\d+)? VUs/g,
     // Init   [   0% ] Loading test script...
@@ -34668,7 +34669,7 @@ function checkIfK6ASCIIArt(data) {
         return true;
     }
 }
-function parseK6Output(data, testRunUrlsMap, totalTestRuns) {
+function parseK6Output(data, testRunUrlsMap, totalTestRuns, showK6ProgressOutput) {
     /*
     * This function is responsible for parsing the output of the k6 command.
     * It filters out the progress lines and logs the rest of the output.
@@ -34677,35 +34678,38 @@ function parseK6Output(data, testRunUrlsMap, totalTestRuns) {
     * @param {Buffer} data - The k6 command output data
     * @param {TestRunUrlsMap | null} testRunUrlsMap - The map containing the script path and output URL. If null, the function will not extract test run URLs.
     * @param {number} totalTestRuns - The total number of test runs. This is used to determine when all test run URLs have been extracted.
+    * @param {boolean} showK6ProgressOutput - A flag to determine if the k6 progress output should be shown or not.
     *
     * @returns {void}
     */
     const dataString = data.toString(), lines = dataString.split('\n');
     // Extract test run URLs
     if (testRunUrlsMap && Object.keys(testRunUrlsMap).length < totalTestRuns) {
-        if (extractTestRunUrl(dataString, testRunUrlsMap)) {
-            // Test URL was extracted successfully and added to the map. 
-            // Ignore further output parsing for this data.
-            return;
-        }
-        if (checkIfK6ASCIIArt(dataString)) {
-            // Ignore the k6 ASCII art.
-            // Checking the k6 ASCII art here because it is printed at the start of execution, 
-            // hence if all the test URLs are extracted, the ASCII art will not be printed. 
+        const testRunUrlExtracted = extractTestRunUrl(dataString, testRunUrlsMap), k6ASCIIArt = checkIfK6ASCIIArt(dataString);
+        if ((testRunUrlExtracted || k6ASCIIArt) && !showK6ProgressOutput) {
+            /*
+                If either the test run URL was extracted successfully or the k6 ASCII art was found,
+                and the k6 progress output is not to be shown, then return.
+            */
             return;
         }
     }
-    const filteredLines = lines.filter((line) => {
-        const isRegexMatch = TEST_RUN_PROGRESS_MSG_REGEXES.some((regex) => regex.test(line));
-        return !isRegexMatch;
-    });
-    if (filteredLines.length < lines.length) {
-        // ignore empty lines only when progress lines output was ignored.
-        if (filteredLines.join("") === "") {
-            return;
-        }
+    if (showK6ProgressOutput) {
+        console.log(dataString);
     }
-    console.log(filteredLines.join('\n'));
+    else {
+        const filteredLines = lines.filter((line) => {
+            const isRegexMatch = TEST_RUN_PROGRESS_MSG_REGEXES.some((regex) => regex.test(line));
+            return !isRegexMatch;
+        });
+        if (filteredLines.length < lines.length) {
+            // ignore empty lines only when progress lines output was ignored.
+            if (filteredLines.join("") === "") {
+                return;
+            }
+        }
+        console.log(filteredLines.join('\n'));
+    }
 }
 exports.parseK6Output = parseK6Output;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,10 @@ export async function run(): Promise<void> {
         const cloudRunLocally = core.getInput('cloud-run-locally', { required: false }) === 'true'
         const onlyVerifyScripts = core.getInput('only-verify-scripts', { required: false }) === 'true'
         const shouldCommentCloudTestRunUrlOnPR = core.getInput('cloud-comment-on-pr', { required: false }) === 'true'
+        const showK6ProgressOutput = core.getInput('show-k6-progress-output', { required: false }) === 'true'
         const allPromises: Promise<void>[] = [];
+
+        core.debug(`Flag to show k6 progress output set to: ${showK6ProgressOutput}`);
 
         core.debug(`🔍 Found following ${testPaths.length} test run files:`);
         testPaths.forEach((testPath, index) => {
@@ -76,7 +79,6 @@ export async function run(): Promise<void> {
                     return true;
                 }
             });
-        ;
 
         let allTestsPassed = true;
 
@@ -191,7 +193,7 @@ export async function run(): Promise<void> {
             });
             // Parse k6 command output and extract test run URLs if running in cloud mode.
             // Also, print the output to the console, excluding the progress lines.
-            child.stdout?.on('data', (data) => parseK6Output(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS));
+            child.stdout?.on('data', (data) => parseK6Output(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS, showK6ProgressOutput));
 
             return child;
         }

--- a/src/k6OutputParser.ts
+++ b/src/k6OutputParser.ts
@@ -7,7 +7,7 @@ const REGEX_EXPRESSIONS = {
     output: /^\s*output:\s*(.+)$/m,
     outputCloudUrl: /cloud\s*\((.+)\)/,
     runningIteration: /running \(.*\), \d+\/\d+ VUs, \d+ complete and \d+ interrupted iterations/g,
-    //  default   [  20% ] 10 VUs  1.0s/5s  
+    //  default   [  20% ] 10 VUs  1.0s/5s
     // createBrowser   [  61% ] 035/500 VUs  0m36.5s/1m0s  5.00 iters/s
     executionProgress: /\[\s*(\d+)%\s*\]\s*\d+(\/\d+)? VUs/g,
     // Init   [   0% ] Loading test script...
@@ -26,14 +26,14 @@ const REGEX_EXPRESSIONS = {
 function extractTestRunUrl(data: string, testRunUrlsMap: TestRunUrlsMap): boolean {
     /**
      * This function extracts the script path and output URL from the k6 output.
-     * It then adds the script path and output URL to the testRunUrlsMap which is a reference to 
+     * It then adds the script path and output URL to the testRunUrlsMap which is a reference to
      * an object passed from the main function to store test run urls mapped to corresponding test script.
-     * 
+     *
      * @param {string} data - The k6 command output data as string
      * @param {TestRunUrlsMap} testRunUrlsMap - The map containing the script path and output URL
-     * 
+     *
      * @returns {boolean} - Returns true if the script path and output URL were successfully extracted and added to the map. Otherwise, returns false.
-     * 
+     *
      */
 
     // Extracting the script path
@@ -58,21 +58,21 @@ function extractTestRunUrl(data: string, testRunUrlsMap: TestRunUrlsMap): boolea
 function checkIfK6ASCIIArt(data: string): boolean {
     /**
      * This function checks if the given data is the k6 ASCII art or not.
-     * 
+     *
      * @param {string} data - The data to check
-     * 
+     *
      * @returns {boolean} - Returns true if the data is the k6 ASCII art. Otherwise, returns false.
-     * 
+     *
      * The k6 ASCII art is as follows:
-     * 
-     * 
-     * 
-     *          /\      |‾‾| /‾‾/   /‾‾/   
-     *     /\  /  \     |  |/  /   /  /    
-     *    /  \/    \    |     (   /   ‾‾\  
-     *   /          \   |  |\  \ |  (‾)  | 
+     *
+     *
+     *
+     *          /\      |‾‾| /‾‾/   /‾‾/
+     *     /\  /  \     |  |/  /   /  /
+     *    /  \/    \    |     (   /   ‾‾\
+     *   /          \   |  |\  \ |  (‾)  |
      *  / __________ \  |__| \__\ \_____/ .io
-     * 
+     *
      * To determine if the data is the k6 ASCII art, the function checks the following:
      * 1. The function checks if the data contains only the following characters:
      *      |, ' ', '\n', '/', '‾', '(', ')', '_', '.', 'i', 'o'
@@ -110,16 +110,17 @@ function checkIfK6ASCIIArt(data: string): boolean {
     }
 }
 
-export function parseK6Output(data: Buffer, testRunUrlsMap: TestRunUrlsMap | null, totalTestRuns: number): void {
+export function parseK6Output(data: Buffer, testRunUrlsMap: TestRunUrlsMap | null, totalTestRuns: number, showK6ProgressOutput: boolean): void {
     /*
-    * This function is responsible for parsing the output of the k6 command. 
+    * This function is responsible for parsing the output of the k6 command.
     * It filters out the progress lines and logs the rest of the output.
     * It also extracts the test run URLs from the output.
-    * 
+    *
     * @param {Buffer} data - The k6 command output data
     * @param {TestRunUrlsMap | null} testRunUrlsMap - The map containing the script path and output URL. If null, the function will not extract test run URLs.
     * @param {number} totalTestRuns - The total number of test runs. This is used to determine when all test run URLs have been extracted.
-    * 
+    * @param {boolean} showK6ProgressOutput - A flag to determine if the k6 progress output should be shown or not.
+    *
     * @returns {void}
     */
 
@@ -128,31 +129,33 @@ export function parseK6Output(data: Buffer, testRunUrlsMap: TestRunUrlsMap | nul
 
     // Extract test run URLs
     if (testRunUrlsMap && Object.keys(testRunUrlsMap).length < totalTestRuns) {
-        if (extractTestRunUrl(dataString, testRunUrlsMap)) {
-            // Test URL was extracted successfully and added to the map. 
-            // Ignore further output parsing for this data.
-            return;
-        }
+        const testRunUrlExtracted = extractTestRunUrl(dataString, testRunUrlsMap),
+            k6ASCIIArt = checkIfK6ASCIIArt(dataString);
 
-        if (checkIfK6ASCIIArt(dataString)) {
-            // Ignore the k6 ASCII art.
-            // Checking the k6 ASCII art here because it is printed at the start of execution, 
-            // hence if all the test URLs are extracted, the ASCII art will not be printed. 
-            return;
-        }
-    }
-
-    const filteredLines = lines.filter((line) => {
-        const isRegexMatch = TEST_RUN_PROGRESS_MSG_REGEXES.some((regex) => regex.test(line));
-
-        return !isRegexMatch;
-    });
-
-    if (filteredLines.length < lines.length) {
-        // ignore empty lines only when progress lines output was ignored.
-        if (filteredLines.join("") === "") {
+        if ((testRunUrlExtracted || k6ASCIIArt) && !showK6ProgressOutput) {
+            /*
+                If either the test run URL was extracted successfully or the k6 ASCII art was found,
+                and the k6 progress output is not to be shown, then return.
+            */
             return;
         }
     }
-    console.log(filteredLines.join('\n'))
+
+    if (showK6ProgressOutput) {
+        console.log(dataString);
+    } else {
+        const filteredLines = lines.filter((line) => {
+            const isRegexMatch = TEST_RUN_PROGRESS_MSG_REGEXES.some((regex) => regex.test(line));
+
+            return !isRegexMatch;
+        });
+
+        if (filteredLines.length < lines.length) {
+            // ignore empty lines only when progress lines output was ignored.
+            if (filteredLines.join("") === "") {
+                return;
+            }
+        }
+        console.log(filteredLines.join('\n'))
+    }
 }


### PR DESCRIPTION
Adds a new input for the action which will skip filtering the K6 command output from the action to improving debugging experience. 

Fixes - #25 

