### PR TITLE
Log stderr on console

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34518,6 +34518,7 @@ async function run() {
             // Parse k6 command output and extract test run URLs if running in cloud mode.
             // Also, print the output to the console, excluding the progress lines.
             child.stdout?.on('data', (data) => (0, k6OutputParser_1.parseK6Output)(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS, debug));
+            child.stderr?.on('data', (data) => console.error(`🚨 ${data.toString()}`));
             return child;
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -34518,7 +34518,7 @@ async function run() {
             // Parse k6 command output and extract test run URLs if running in cloud mode.
             // Also, print the output to the console, excluding the progress lines.
             child.stdout?.on('data', (data) => (0, k6OutputParser_1.parseK6Output)(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS, debug));
-            child.stderr?.on('data', (data) => console.error(`🚨 ${data.toString()}`));
+            child.stderr?.on('data', (data) => process.stderr.write(`🚨 ${data.toString()}`));
             return child;
         }
     }
@@ -34696,7 +34696,7 @@ function parseK6Output(data, testRunUrlsMap, totalTestRuns, debug) {
         }
     }
     if (debug) {
-        console.log(dataString);
+        process.stdout.write(data);
     }
     else {
         const filteredLines = lines.filter((line) => {
@@ -34709,7 +34709,7 @@ function parseK6Output(data, testRunUrlsMap, totalTestRuns, debug) {
                 return;
             }
         }
-        console.log(filteredLines.join('\n'));
+        process.stdout.write(filteredLines.join('\n'));
     }
 }
 exports.parseK6Output = parseK6Output;

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ export async function run(): Promise<void> {
             // Parse k6 command output and extract test run URLs if running in cloud mode.
             // Also, print the output to the console, excluding the progress lines.
             child.stdout?.on('data', (data) => parseK6Output(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS, debug));
+            child.stderr?.on('data', (data) => console.error(`🚨 ${data.toString()}`));
 
             return child;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ export async function run(): Promise<void> {
             // Parse k6 command output and extract test run URLs if running in cloud mode.
             // Also, print the output to the console, excluding the progress lines.
             child.stdout?.on('data', (data) => parseK6Output(data, TEST_RESULT_URLS_MAP, TOTAL_TEST_RUNS, debug));
-            child.stderr?.on('data', (data) => console.error(`🚨 ${data.toString()}`));
+            child.stderr?.on('data', (data) => process.stderr.write(`🚨 ${data.toString()}`));
 
             return child;
         }

--- a/src/k6OutputParser.ts
+++ b/src/k6OutputParser.ts
@@ -142,7 +142,7 @@ export function parseK6Output(data: Buffer, testRunUrlsMap: TestRunUrlsMap | nul
     }
 
     if (debug) {
-        console.log(dataString);
+        process.stdout.write(data);
     } else {
         const filteredLines = lines.filter((line) => {
             const isRegexMatch = TEST_RUN_PROGRESS_MSG_REGEXES.some((regex) => regex.test(line));
@@ -156,6 +156,6 @@ export function parseK6Output(data: Buffer, testRunUrlsMap: TestRunUrlsMap | nul
                 return;
             }
         }
-        console.log(filteredLines.join('\n'))
+        process.stdout.write(filteredLines.join('\n'))
     }
 }


### PR DESCRIPTION
Currently, the stderr is ignored which makes debugging a little difficult. These changes show the stderr output on the console

Fixes - #22 