### PR TITLE
fix: parallel false not working

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34448,7 +34448,7 @@ async function run() {
             for (const command of commands) {
                 const child = runCommand(command);
                 TEST_PIDS.push(child.pid);
-                allPromises.push(new Promise(resolve => {
+                await new Promise(resolve => {
                     child.on('exit', (code, signal) => {
                         const index = TEST_PIDS.indexOf(child.pid);
                         if (index > -1) {
@@ -34469,7 +34469,7 @@ async function run() {
                         }
                         resolve();
                     });
-                }));
+                });
             }
         }
         await Promise.all(allPromises);

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ export async function run(): Promise<void> {
             for (const command of commands) {
                 const child = runCommand(command);
                 TEST_PIDS.push(child.pid);
-                allPromises.push(new Promise<void>(resolve => {
+                await new Promise<void>(resolve => {
                     child.on('exit', (code: number, signal: string) => {
                         const index = TEST_PIDS.indexOf(child.pid);
                         if (index > -1) {
@@ -143,7 +143,7 @@ export async function run(): Promise<void> {
                         }
                         resolve();
                     });
-                }));
+                });
             }
         }
         await Promise.all(allPromises);


### PR DESCRIPTION
This PR fixes `parallel: false` which currently still results in tests running in parallel.

Closes #30
