### PR TITLE
Test for the issue reported with environment variables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,4 +96,5 @@ jobs:
         with:
           path: |
             ./dev/env-var-test.js
-          flags: --vus 1 --duration 1s --env TEST_FLAG_ENV_VAR=test-flag-env-var-value -e TEST_SYSTEM_ENV_VAR_E=test-cli-e-env-var-value
+          flags: --vus 1 --duration 1s --env TEST_FLAG_ENV_VAR=test-flag-env-var-value -e TEST_SYSTEM_ENV_VAR_E=test-cli-e-env-var-value -e ENVIRONMENT=prod
+          inspect-flags: --include-system-env-vars

--- a/dev/env-var-test.js
+++ b/dev/env-var-test.js
@@ -6,6 +6,8 @@ export const options = {
   },
 }
 
+const data = JSON.parse(open(`./${__ENV.ENVIRONMENT}-data.json`))
+
 export default function () {
   check(__ENV, {
     'System env var': (env) =>
@@ -14,5 +16,9 @@ export default function () {
       env.TEST_FLAG_ENV_VAR === 'test-flag-env-var-value',
     'CLI -e flag set': (env) =>
       env.TEST_SYSTEM_ENV_VAR_E === 'test-cli-e-env-var-value',
+  })
+
+  check(data, {
+    'Username is john_doe': (data) => data.username == 'john_doe',
   })
 }

--- a/dev/prod-data.json
+++ b/dev/prod-data.json
@@ -1,0 +1,3 @@
+{
+  "username": "john_doe"
+}


### PR DESCRIPTION
Hey @DefCon-007 I have added a test for the issue reported on #28 

Even though the --include-system-env-vars flag is provided, the environment variables are not available in the inspect engine and is not possible currently to disable the inspection step.

![image](https://github.com/user-attachments/assets/e4b036e5-c670-42f6-87b1-d4f23ad2ea17)
