### PR TITLE
Update flag parsing to account for possible whitespace

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35565,6 +35565,7 @@ const analytics_1 = __nccwpck_require__(1267);
 const githubHelper_1 = __nccwpck_require__(2384);
 const k6helper_1 = __nccwpck_require__(5354);
 const utils_1 = __nccwpck_require__(1798);
+const string_argv_1 = __nccwpck_require__(1024);
 const TEST_PIDS = [];
 run();
 /**
@@ -35592,7 +35593,7 @@ async function run() {
         if (testPaths.length === 0) {
             throw new Error('No test files found');
         }
-        const verifiedTestPaths = await (0, k6helper_1.validateTestPaths)(testPaths, inspectFlags ? inspectFlags.split(' ') : []);
+        const verifiedTestPaths = await (0, k6helper_1.validateTestPaths)(testPaths, inspectFlags ? (0, string_argv_1.parseArgsStringToArgv)(inspectFlags) : []);
         if (verifiedTestPaths.length === 0) {
             throw new Error('No valid test files found');
         }
@@ -35958,6 +35959,7 @@ const child_process_1 = __nccwpck_require__(5317);
 const path_1 = __importDefault(__nccwpck_require__(6928));
 const apiUtils_1 = __nccwpck_require__(890);
 const k6OutputParser_1 = __nccwpck_require__(7076);
+const string_argv_1 = __nccwpck_require__(1024);
 function getK6CloudBaseUrl() {
     return process.env.K6_CLOUD_BASE_URL || 'https://api.k6.io';
 }
@@ -36077,7 +36079,7 @@ function generateK6RunCommand(path, flags, isCloud, cloudRunLocally) {
     return command;
 }
 function executeRunK6Command(command, totalTestRuns, testResultUrlsMap, debug) {
-    const parts = command.split(' ');
+    const parts = (0, string_argv_1.parseArgsStringToArgv)(command);
     const cmd = parts[0];
     const args = parts.slice(1);
     console.log(`🤖 Running test: ${cmd} ${args.join(' ')}`);
@@ -38449,6 +38451,59 @@ function parseParams (str) {
 }
 
 module.exports = parseParams
+
+
+/***/ }),
+
+/***/ 1024:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+exports.__esModule = true;
+exports.parseArgsStringToArgv = void 0;
+function parseArgsStringToArgv(value, env, file) {
+    // ([^\s'"]([^\s'"]*(['"])([^\3]*?)\3)+[^\s'"]*) Matches nested quotes until the first space outside of quotes
+    // [^\s'"]+ or Match if not a space ' or "
+    // (['"])([^\5]*?)\5 or Match "quoted text" without quotes
+    // `\3` and `\5` are a backreference to the quote style (' or ") captured
+    var myRegexp = /([^\s'"]([^\s'"]*(['"])([^\3]*?)\3)+[^\s'"]*)|[^\s'"]+|(['"])([^\5]*?)\5/gi;
+    var myString = value;
+    var myArray = [];
+    if (env) {
+        myArray.push(env);
+    }
+    if (file) {
+        myArray.push(file);
+    }
+    var match;
+    do {
+        // Each call to exec returns the next regex match as an array
+        match = myRegexp.exec(myString);
+        if (match !== null) {
+            // Index 1 in the array is the captured group if it exists
+            // Index 0 is the matched text, which we use if no captured group exists
+            myArray.push(firstString(match[1], match[6], match[0]));
+        }
+    } while (match !== null);
+    return myArray;
+}
+exports["default"] = parseArgsStringToArgv;
+exports.parseArgsStringToArgv = parseArgsStringToArgv;
+// Accepts any number of arguments, and returns the first one that is a string
+// (even an empty string)
+function firstString() {
+    var args = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+    }
+    for (var i = 0; i < args.length; i++) {
+        var arg = args[i];
+        if (typeof arg === "string") {
+            return arg;
+        }
+    }
+}
 
 
 /***/ })

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@actions/tool-cache": "^2.0.1",
         "@vercel/ncc": "^0.38.1",
         "chmodr": "^1.2.0",
-        "fs-extra": "^11.2.0"
+        "fs-extra": "^11.2.0",
+        "string-argv": "^0.3.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -4845,6 +4846,15 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
       "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
       "dev": true
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@actions/tool-cache": "^2.0.1",
     "@vercel/ncc": "^0.38.1",
     "chmodr": "^1.2.0",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "string-argv": "^0.3.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from './k6helper'
 import { TestRunUrlsMap } from './types'
 import { findTestsToRun } from './utils'
+import { parseArgsStringToArgv } from 'string-argv'
 
 const TEST_PIDS: number[] = []
 
@@ -50,7 +51,7 @@ export async function run(): Promise<void> {
 
     const verifiedTestPaths = await validateTestPaths(
       testPaths,
-      inspectFlags ? inspectFlags.split(' ') : []
+      inspectFlags ? parseArgsStringToArgv(inspectFlags) : []
     )
 
     if (verifiedTestPaths.length === 0) {

--- a/src/k6helper.ts
+++ b/src/k6helper.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { apiRequest, DEFAULT_RETRY_OPTIONS } from './apiUtils'
 import { parseK6Output } from './k6OutputParser'
 import { Check, ChecksResponse, TestRunSummary, TestRunUrlsMap } from './types'
+import { parseArgsStringToArgv } from 'string-argv'
 
 function getK6CloudBaseUrl(): string {
   return process.env.K6_CLOUD_BASE_URL || 'https://api.k6.io'
@@ -170,7 +171,7 @@ export function executeRunK6Command(
   testResultUrlsMap: TestRunUrlsMap,
   debug: boolean
 ): ChildProcess {
-  const parts = command.split(' ')
+  const parts = parseArgsStringToArgv(command)
   const cmd = parts[0]
   const args = parts.slice(1)
 


### PR DESCRIPTION
Updates the way flags are parsed using string-argv instead of a simple split(' '). This fixes https://github.com/grafana/run-k6-action/issues/44.

It's worth noting that split(' ') was left in the genrateK6RunCommand function, as string-argv doesn't maintain the integrity of the quotations, which would then parse split parts as separate args within the executeRunK6Command. On top of this, the array is split and then later rejoined on space characters, so leaving it should be fine (though this might be something to address as a cleanup at some point)