### PR TITLE
Output testRunIds to GitHub workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ Comment Grafana cloud k6 test URL on PR
     style="pointer-events: none;" />
 </div>
 
+Output testRunIds to GitHub workflow 
+
+```yaml
+jobs:
+  run-k6:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run k6 test
+      id: run_k6
+      uses: grafana/run-k6-action@v1
+      with:
+        path: |
+          ./tests/api*.js
+      env:
+        K6_CLOUD_TOKEN: ${{ secrets.K6_CLOUD_TOKEN }}
+        K6_CLOUD_PROJECT_ID: ${{ secrets.K6_CLOUD_PROJECT_ID }}
+
+    - name: Print test run IDs
+      run: echo "Test run IDs - $TEST_RUN_IDS"
+      env:
+        TEST_RUN_IDS: ${{ steps.run_k6.outputs.testRunIds }}
+```
+
 Typescript [Compatibility Mode](https://grafana.com/docs/k6/latest/using-k6/javascript-typescript-compatibility-mode/#javascript-and-typescript-compatibility-mode)
 
 ```yaml

--- a/dist/index.js
+++ b/dist/index.js
@@ -35708,9 +35708,21 @@ async function run() {
             }
         }
         await Promise.all(allPromises);
-        if (isCloud && shouldCommentOnPR) {
-            // Generate PR comment with test run URLs
-            await (0, githubHelper_1.generatePRComment)(TEST_RESULT_URLS_MAP);
+        if (isCloud) {
+            const testRunIds = {};
+            for (const [scriptPath, testRunUrl] of Object.entries(TEST_RESULT_URLS_MAP)) {
+                const testRunId = (0, k6helper_1.extractTestRunId)(testRunUrl);
+                if (testRunId) {
+                    testRunIds[scriptPath] = testRunId;
+                }
+            }
+            // Output the testRunIds as a JSON string
+            core.setOutput('testRunIds', JSON.stringify(testRunIds));
+            core.debug('TestRunIds have been set as an output successfully.');
+            if (shouldCommentOnPR) {
+                // Generate PR comment with test run URLs
+                await (0, githubHelper_1.generatePRComment)(TEST_RESULT_URLS_MAP);
+            }
         }
         if (!allTestsPassed) {
             console.log('🚨 Some tests failed');

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,6 +12,7 @@ vi.mock('@actions/core', () => ({
   getBooleanInput: vi.fn(),
   setFailed: vi.fn(),
   debug: vi.fn(),
+  setOutput: vi.fn(),
 }))
 
 vi.mock('child_process', () => ({
@@ -47,6 +48,7 @@ vi.mock('../src/k6helper', () => ({
   generateK6RunCommand: vi.fn(),
   isCloudIntegrationEnabled: vi.fn(),
   cleanScriptPath: vi.fn(),
+  extractTestRunId: vi.fn(),
 }))
 
 vi.mock('../src/githubHelper', () => ({
@@ -456,4 +458,56 @@ describe('run function', () => {
       false
     )
   })
+
+  it('should extract and output the testRunIds', async () => {
+    // Mock input values
+    vi.mocked(core.getInput).mockImplementation((name) => {
+      if (name === 'path') return 'test/*.js';
+      return '';
+    });
+  
+    vi.mocked(core.getBooleanInput).mockImplementation((name) => {
+      if (name === 'parallel') return true;
+      if (name === 'cloud-comment-on-pr') return true;
+      return false;
+    });
+  
+    // Mock test paths
+    vi.mocked(utils.findTestsToRun).mockResolvedValue(['test1.js']);
+    vi.mocked(k6helper.validateTestPaths).mockResolvedValue(['test1.js']);
+    vi.mocked(k6helper.isCloudIntegrationEnabled).mockReturnValue(true);
+    vi.mocked(k6helper.generateK6RunCommand).mockReturnValue('k6 cloud test1.js');
+  
+    // Mock execution of `k6 run` command
+    vi.mocked(k6helper.executeRunK6Command).mockImplementation((command, totalRuns, resultUrlsMap) => {
+      console.log('Mock executeRunK6Command called with:', { command, totalRuns, resultUrlsMap });
+      Object.assign(resultUrlsMap, {
+        'test1.js': 'https://example.com/testRun1',
+      });
+      return {
+        on: vi.fn((event, callback) => {
+          if (event === 'exit') callback(0, '');
+        }),
+        pid: 123,
+      } as unknown as ChildProcess;
+    });
+  
+    // Mock `extractTestRunId`
+    vi.mocked(k6helper.extractTestRunId).mockImplementation((url) => {
+      if (url === 'https://example.com/testRun1') return 'testRunId1';
+      return null;
+    });
+  
+    // Run the function
+    await run();
+  
+    // Verify `extractTestRunId` is called
+    expect(k6helper.extractTestRunId).toHaveBeenCalledWith('https://example.com/testRun1');
+  
+    // Verify `core.setOutput` is called with the correct arguments
+    expect(core.setOutput).toHaveBeenCalledWith(
+      'testRunIds',
+      JSON.stringify({ 'test1.js': 'testRunId1' })
+    )
+  })  
 })


### PR DESCRIPTION
This change outputs the K6 Cloud test run IDs to the GitHub workflow that called the run-k6-action. 

It allows future workflow steps to retrieve extra information on the test run by using the K6 Cloud API (`https://api.k6.io/cloud/v6/test_runs/{test_run_id}`). For example, creating a [GitHub summary](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary) that shows the test run status, duration, virtual user hours, etc. 