### PR TITLE
chore: update missing with: for advanced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: grafana/setup-k6-action@v1
+        with:
           browser: true
       - uses: grafana/run-k6-action@v1
         with:
@@ -172,6 +173,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: grafana/setup-k6-action@v1
+        with:
           browser: true
       - uses: grafana/run-k6-action@v1
         with:


### PR DESCRIPTION
Just a tiny update in readme, it was missing a with: key.