### PR TITLE
Allow using spaces in flags and inspect-flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,4 +123,4 @@ jobs:
         with:
           path: |
             ./dev/env-var-test.js
-          flags: --vus 1 --duration 1s --env TEST_FLAG_ENV_VAR=test-flag-env-var-value -e TEST_SYSTEM_ENV_VAR_E=test-cli-e-env-var-value
+          flags: --vus 1 --duration 1s --env TEST_FLAG_ENV_VAR=test-flag-env-var-value -e TEST_SYSTEM_ENV_VAR_CLI="system env var value from CLI"

--- a/dev/env-var-test.js
+++ b/dev/env-var-test.js
@@ -13,6 +13,6 @@ export default function () {
     'CLI --env flag set': (env) =>
       env.TEST_FLAG_ENV_VAR === 'test-flag-env-var-value',
     'CLI -e flag set': (env) =>
-      env.TEST_SYSTEM_ENV_VAR_E === 'test-cli-e-env-var-value',
+      env.TEST_SYSTEM_ENV_VAR_CLI === 'system env var value from CLI',
   })
 }

--- a/dist/579.index.js
+++ b/dist/579.index.js
@@ -1,0 +1,59 @@
+"use strict";
+exports.id = 579;
+exports.ids = [579];
+exports.modules = {
+
+/***/ 8579:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   parseArgsStringToArgv: () => (/* binding */ parseArgsStringToArgv)
+/* harmony export */ });
+/* unused harmony export default */
+
+function parseArgsStringToArgv(value, env, file) {
+    // ([^\s'"]([^\s'"]*(['"])([^\3]*?)\3)+[^\s'"]*) Matches nested quotes until the first space outside of quotes
+    // [^\s'"]+ or Match if not a space ' or "
+    // (['"])([^\5]*?)\5 or Match "quoted text" without quotes
+    // `\3` and `\5` are a backreference to the quote style (' or ") captured
+    var myRegexp = /([^\s'"]([^\s'"]*(['"])([^\3]*?)\3)+[^\s'"]*)|[^\s'"]+|(['"])([^\5]*?)\5/gi;
+    var myString = value;
+    var myArray = [];
+    if (env) {
+        myArray.push(env);
+    }
+    if (file) {
+        myArray.push(file);
+    }
+    var match;
+    do {
+        // Each call to exec returns the next regex match as an array
+        match = myRegexp.exec(myString);
+        if (match !== null) {
+            // Index 1 in the array is the captured group if it exists
+            // Index 0 is the matched text, which we use if no captured group exists
+            myArray.push(firstString(match[1], match[6], match[0]));
+        }
+    } while (match !== null);
+    return myArray;
+}
+// Accepts any number of arguments, and returns the first one that is a string
+// (even an empty string)
+function firstString() {
+    var args = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+    }
+    for (var i = 0; i < args.length; i++) {
+        var arg = args[i];
+        if (typeof arg === "string") {
+            return arg;
+        }
+    }
+}
+
+
+/***/ })
+
+};
+;

--- a/dist/index.js
+++ b/dist/index.js
@@ -35576,8 +35576,8 @@ async function run() {
         const testPaths = await (0, utils_1.findTestsToRun)(core.getInput('path', { required: true }));
         const parallel = core.getBooleanInput('parallel');
         const failFast = core.getBooleanInput('fail-fast');
-        const flags = core.getInput('flags');
-        const inspectFlags = core.getInput('inspect-flags');
+        const flags = await (0, utils_1.parseStringToCLIArgs)(core.getInput('flags'));
+        const inspectFlags = await (0, utils_1.parseStringToCLIArgs)(core.getInput('inspect-flags'));
         const cloudRunLocally = core.getBooleanInput('cloud-run-locally');
         const onlyVerifyScripts = core.getBooleanInput('only-verify-scripts');
         const shouldCommentOnPR = core.getBooleanInput('cloud-comment-on-pr');
@@ -35592,7 +35592,7 @@ async function run() {
         if (testPaths.length === 0) {
             throw new Error('No test files found');
         }
-        const verifiedTestPaths = await (0, k6helper_1.validateTestPaths)(testPaths, inspectFlags ? inspectFlags.split(' ') : []);
+        const verifiedTestPaths = await (0, k6helper_1.validateTestPaths)(testPaths, inspectFlags);
         if (verifiedTestPaths.length === 0) {
             throw new Error('No valid test files found');
         }
@@ -36064,7 +36064,7 @@ function isCloudIntegrationEnabled() {
  */
 function generateK6RunCommand(path, flags, isCloud, cloudRunLocally) {
     let command;
-    const args = [`--address=`, ...(flags ? flags.split(' ') : [])];
+    const args = [`--address=''`, ...flags];
     if (isCloud) {
         // Cloud execution is possible for the test
         if (cloudRunLocally) {
@@ -36552,6 +36552,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isDirectory = isDirectory;
 exports.findTestsToRun = findTestsToRun;
+exports.parseStringToCLIArgs = parseStringToCLIArgs;
 const glob = __importStar(__nccwpck_require__(7206));
 const fs = __importStar(__nccwpck_require__(2136));
 /**
@@ -36579,6 +36580,24 @@ async function findTestsToRun(path) {
     const globber = await glob.create(path);
     const files = await globber.glob();
     return files.filter((file) => !isDirectory(file));
+}
+/**
+ * Parses a string containing command-line arguments into an array of individual arguments.
+ * This function handles quoted strings, escaped characters, and other CLI argument formatting
+ * that would typically be processed by a shell.
+ *
+ * @param {string} input - The input string containing command-line arguments
+ * @returns {Promise<string[]>} - A promise that resolves to an array of parsed command-line arguments
+ * @example
+ * await parseStringToCLIArgs('--flag value "quoted string"')
+ * // Returns: ['--flag', 'value', 'quoted string']
+ */
+async function parseStringToCLIArgs(input) {
+    if (input === '' || input === null || input === undefined) {
+        return [];
+    }
+    const { parseArgsStringToArgv } = await __nccwpck_require__.e(/* import() */ 579).then(__nccwpck_require__.bind(__nccwpck_require__, 8579));
+    return parseArgsStringToArgv(input);
 }
 
 
@@ -38497,10 +38516,94 @@ module.exports = parseParams
 /******/ 		return module.exports;
 /******/ 	}
 /******/ 	
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__nccwpck_require__.m = __webpack_modules__;
+/******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/ensure chunk */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.f = {};
+/******/ 		// This file contains only the entry chunk.
+/******/ 		// The chunk loading function for additional chunks
+/******/ 		__nccwpck_require__.e = (chunkId) => {
+/******/ 			return Promise.all(Object.keys(__nccwpck_require__.f).reduce((promises, key) => {
+/******/ 				__nccwpck_require__.f[key](chunkId, promises);
+/******/ 				return promises;
+/******/ 			}, []));
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/get javascript chunk filename */
+/******/ 	(() => {
+/******/ 		// This function allow to reference async chunks
+/******/ 		__nccwpck_require__.u = (chunkId) => {
+/******/ 			// return url for filenames based on template
+/******/ 			return "" + chunkId + ".index.js";
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/******/ 	/* webpack/runtime/require chunk loading */
+/******/ 	(() => {
+/******/ 		// no baseURI
+/******/ 		
+/******/ 		// object to store loaded chunks
+/******/ 		// "1" means "loaded", otherwise not loaded yet
+/******/ 		var installedChunks = {
+/******/ 			792: 1
+/******/ 		};
+/******/ 		
+/******/ 		// no on chunks loaded
+/******/ 		
+/******/ 		var installChunk = (chunk) => {
+/******/ 			var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
+/******/ 			for(var moduleId in moreModules) {
+/******/ 				if(__nccwpck_require__.o(moreModules, moduleId)) {
+/******/ 					__nccwpck_require__.m[moduleId] = moreModules[moduleId];
+/******/ 				}
+/******/ 			}
+/******/ 			if(runtime) runtime(__nccwpck_require__);
+/******/ 			for(var i = 0; i < chunkIds.length; i++)
+/******/ 				installedChunks[chunkIds[i]] = 1;
+/******/ 		
+/******/ 		};
+/******/ 		
+/******/ 		// require() chunk loading for javascript
+/******/ 		__nccwpck_require__.f.require = (chunkId, promises) => {
+/******/ 			// "1" is the signal for "already loaded"
+/******/ 			if(!installedChunks[chunkId]) {
+/******/ 				if(true) { // all chunks have JS
+/******/ 					installChunk(require("./" + __nccwpck_require__.u(chunkId)));
+/******/ 				} else installedChunks[chunkId] = 1;
+/******/ 			}
+/******/ 		};
+/******/ 		
+/******/ 		// no external install chunk
+/******/ 		
+/******/ 		// no HMR
+/******/ 		
+/******/ 		// no HMR manifest
+/******/ 	})();
 /******/ 	
 /************************************************************************/
 /******/ 	

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@actions/tool-cache": "^2.0.1",
         "@vercel/ncc": "^0.38.1",
         "chmodr": "^1.2.0",
-        "fs-extra": "^11.2.0"
+        "fs-extra": "^11.2.0",
+        "string-argv": "^0.3.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -4845,6 +4846,15 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
       "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
       "dev": true
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@actions/tool-cache": "^2.0.1",
     "@vercel/ncc": "^0.38.1",
     "chmodr": "^1.2.0",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "string-argv": "^0.3.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   validateTestPaths,
 } from './k6helper'
 import { TestRunUrlsMap } from './types'
-import { findTestsToRun } from './utils'
+import { findTestsToRun, parseStringToCLIArgs } from './utils'
 
 const TEST_PIDS: number[] = []
 
@@ -29,8 +29,10 @@ export async function run(): Promise<void> {
     )
     const parallel = core.getBooleanInput('parallel')
     const failFast = core.getBooleanInput('fail-fast')
-    const flags = core.getInput('flags')
-    const inspectFlags = core.getInput('inspect-flags')
+    const flags = await parseStringToCLIArgs(core.getInput('flags'))
+    const inspectFlags = await parseStringToCLIArgs(
+      core.getInput('inspect-flags')
+    )
     const cloudRunLocally = core.getBooleanInput('cloud-run-locally')
     const onlyVerifyScripts = core.getBooleanInput('only-verify-scripts')
     const shouldCommentOnPR = core.getBooleanInput('cloud-comment-on-pr')
@@ -49,10 +51,7 @@ export async function run(): Promise<void> {
       throw new Error('No test files found')
     }
 
-    const verifiedTestPaths = await validateTestPaths(
-      testPaths,
-      inspectFlags ? inspectFlags.split(' ') : []
-    )
+    const verifiedTestPaths = await validateTestPaths(testPaths, inspectFlags)
 
     if (verifiedTestPaths.length === 0) {
       throw new Error('No valid test files found')

--- a/src/k6helper.ts
+++ b/src/k6helper.ts
@@ -132,12 +132,12 @@ export function isCloudIntegrationEnabled(): boolean {
  */
 export function generateK6RunCommand(
   path: string,
-  flags: string,
+  flags: string[],
   isCloud: boolean,
   cloudRunLocally: boolean
 ): string {
   let command
-  const args = [`--address=`, ...(flags ? flags.split(' ') : [])]
+  const args = [`--address=`, ...flags]
 
   if (isCloud) {
     // Cloud execution is possible for the test

--- a/src/k6helper.ts
+++ b/src/k6helper.ts
@@ -137,7 +137,7 @@ export function generateK6RunCommand(
   cloudRunLocally: boolean
 ): string {
   let command
-  const args = [`--address=`, ...flags]
+  const args = [`--address=''`, ...flags]
 
   if (isCloud) {
     // Cloud execution is possible for the test

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,3 +28,23 @@ export async function findTestsToRun(path: string): Promise<string[]> {
   const files = await globber.glob()
   return files.filter((file) => !isDirectory(file))
 }
+
+/**
+ * Parses a string containing command-line arguments into an array of individual arguments.
+ * This function handles quoted strings, escaped characters, and other CLI argument formatting
+ * that would typically be processed by a shell.
+ *
+ * @param {string} input - The input string containing command-line arguments
+ * @returns {Promise<string[]>} - A promise that resolves to an array of parsed command-line arguments
+ * @example
+ * await parseStringToCLIArgs('--flag value "quoted string"')
+ * // Returns: ['--flag', 'value', 'quoted string']
+ */
+export async function parseStringToCLIArgs(input: string): Promise<string[]> {
+  if (input === '' || input === null || input === undefined) {
+    return []
+  }
+
+  const { parseArgsStringToArgv } = await import('string-argv')
+  return parseArgsStringToArgv(input)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import * as glob from '@actions/glob'
-
 import * as fs from 'fs-extra'
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,9 +34,13 @@ vi.mock('child_process', () => ({
   })),
 }))
 
-vi.mock('../src/utils', () => ({
-  findTestsToRun: vi.fn(),
-}))
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual('../src/utils')
+  return {
+    ...actual, // Keep all original functions
+    findTestsToRun: vi.fn(),
+  }
+})
 
 vi.mock('../src/analytics', () => ({
   sendAnalytics: vi.fn(),
@@ -453,7 +457,7 @@ describe('run function', () => {
     expect(k6helper.isCloudIntegrationEnabled).toHaveBeenCalled()
     expect(k6helper.generateK6RunCommand).toHaveBeenCalledWith(
       'test1.js',
-      '',
+      [],
       true,
       false
     )

--- a/test/k6helper.test.ts
+++ b/test/k6helper.test.ts
@@ -136,7 +136,7 @@ describe('generateK6RunCommand', () => {
     const isCloud = false
     const cloudRunLocally = false
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
-    expect(result).toBe('k6 run --address= test.js')
+    expect(result).toBe("k6 run --address='' test.js")
   })
 
   it('should generate a cloud k6 run command when isCloud is true and cloudRunLocally is false', () => {
@@ -145,7 +145,7 @@ describe('generateK6RunCommand', () => {
     const isCloud = true
     const cloudRunLocally = false
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
-    expect(result).toBe('k6 cloud --address= test.js')
+    expect(result).toBe("k6 cloud --address='' test.js")
   })
 
   it('should generate a local k6 run command with cloud output when isCloud is true and cloudRunLocally is true', () => {
@@ -154,7 +154,7 @@ describe('generateK6RunCommand', () => {
     const isCloud = true
     const cloudRunLocally = true
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
-    expect(result).toBe('k6 run --address= --out=cloud test.js')
+    expect(result).toBe("k6 run --address='' --out=cloud test.js")
   })
 
   it('should include provided flags in the command', async () => {
@@ -163,7 +163,7 @@ describe('generateK6RunCommand', () => {
     const isCloud = false
     const cloudRunLocally = false
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
-    expect(result).toBe('k6 run --address= --vus=10 --duration=30s test.js')
+    expect(result).toBe("k6 run --address='' --vus=10 --duration=30s test.js")
   })
 })
 

--- a/test/k6helper.test.ts
+++ b/test/k6helper.test.ts
@@ -12,6 +12,7 @@ import {
   validateTestPaths,
 } from '../src/k6helper'
 import { TestRunUrlsMap } from '../src/types'
+import { parseStringToCLIArgs } from '../src/utils'
 
 // Mock child_process.spawn
 vi.mock('child_process', () => ({
@@ -131,7 +132,7 @@ describe('isCloudIntegrationEnabled', () => {
 describe('generateK6RunCommand', () => {
   it('should generate a local k6 run command when isCloud is false', () => {
     const path = 'test.js'
-    const flags = ''
+    const flags = []
     const isCloud = false
     const cloudRunLocally = false
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
@@ -140,7 +141,7 @@ describe('generateK6RunCommand', () => {
 
   it('should generate a cloud k6 run command when isCloud is true and cloudRunLocally is false', () => {
     const path = 'test.js'
-    const flags = ''
+    const flags = []
     const isCloud = true
     const cloudRunLocally = false
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
@@ -149,16 +150,16 @@ describe('generateK6RunCommand', () => {
 
   it('should generate a local k6 run command with cloud output when isCloud is true and cloudRunLocally is true', () => {
     const path = 'test.js'
-    const flags = ''
+    const flags = []
     const isCloud = true
     const cloudRunLocally = true
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)
     expect(result).toBe('k6 run --address= --out=cloud test.js')
   })
 
-  it('should include provided flags in the command', () => {
+  it('should include provided flags in the command', async () => {
     const path = 'test.js'
-    const flags = '--vus=10 --duration=30s'
+    const flags = await parseStringToCLIArgs('--vus=10 --duration=30s')
     const isCloud = false
     const cloudRunLocally = false
     const result = generateK6RunCommand(path, flags, isCloud, cloudRunLocally)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -112,6 +112,10 @@ describe('utils', () => {
         input: '--flag1 "string with space and \'" ',
         expected: ['--flag1', "string with space and '"],
       },
+      {
+        input: '--vus=10 --duration=30s',
+        expected: ['--vus=10', '--duration=30s'],
+      },
     ]
 
     testCases.forEach(({ input, expected }) => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra'
 import * as os from 'os'
 import * as path from 'path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { findTestsToRun, isDirectory } from '../src/utils'
+import { findTestsToRun, isDirectory, parseStringToCLIArgs } from '../src/utils'
 
 describe('utils', () => {
   // Create a temporary test directory structure in the system temp directory
@@ -80,6 +80,45 @@ describe('utils', () => {
 
       const testFiles = await findTestsToRun(`${tempDir}/subset*.js`)
       expect(testFiles).toEqual([testFile1, testFile2])
+    })
+  })
+
+  describe('parseStringToCLIArgs', () => {
+    const testCases = [
+      {
+        input: '--flag value "quoted string"',
+        expected: ['--flag', 'value', 'quoted string'],
+      },
+      {
+        input: '--flag1 value1 --flag2 value2',
+        expected: ['--flag1', 'value1', '--flag2', 'value2'],
+      },
+      {
+        input: '--flag1 value1 --flag2 value2 "quoted string"',
+        expected: ['--flag1', 'value1', '--flag2', 'value2', 'quoted string'],
+      },
+      {
+        input: '--flag1 value1 --flag2 "quoted string" --flag3 value3',
+        expected: [
+          '--flag1',
+          'value1',
+          '--flag2',
+          'quoted string',
+          '--flag3',
+          'value3',
+        ],
+      },
+      {
+        input: '--flag1 "string with space and \'" ',
+        expected: ['--flag1', "string with space and '"],
+      },
+    ]
+
+    testCases.forEach(({ input, expected }) => {
+      it(`should parse ${input}`, async () => {
+        const args = await parseStringToCLIArgs(input)
+        expect(args).toEqual(expected)
+      })
     })
   })
 })


### PR DESCRIPTION
Parse CLI flags which contain spaces properly

Fix #44 