### PR TITLE
Replace github CI/CD secrets for Vault secrets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,10 +44,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      K6_CLOUD_TOKEN: ${{ secrets.K6_CLOUD_TOKEN }}
-      K6_CLOUD_PROJECT_ID: ${{ secrets.K6_CLOUD_PROJECT_ID }}
+      id-token: write
     steps:
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
+        with:
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          # Also stored in 1Password as "k6 Cloud CI/CD Secrets" (Vault is write-only)
+          repo_secrets: |
+            K6_CLOUD_TOKEN=k6-cloud:token
+            K6_CLOUD_PROJECT_ID=k6-cloud:project-id
       - uses: actions/checkout@v4
         with:
           persist-credentials: false


### PR DESCRIPTION
This is part of the new company security policy