### PR TITLE
[feat] Add renovate config to run npm package command

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "postUpgradeTasks": {
+    "commands": ["npm ci", "npm run package"],
+    "fileFilters": ["dist/**", "package-lock.json"],
+    "executionMode": "branch"
+  }
+}


### PR DESCRIPTION
This changes runs the `npm run package` command on renovate PR's to generate the distribution files as well. 