### PR TITLE
fix: handle multiline patterns and negations in findTestsToRun

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -65514,7 +65514,7 @@ async function findTestsToRun(path) {
         .map((l) => l.trim())
         .filter((l) => l.length > 0);
     const includes = lines.filter((l) => !l.startsWith('!'));
-    const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1));
+    const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1).trim());
     const seen = new Set();
     const files = [];
     for (const pattern of includes) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -65514,7 +65514,9 @@ async function findTestsToRun(path) {
         .map((l) => l.trim())
         .filter((l) => l.length > 0);
     const includes = lines.filter((l) => !l.startsWith('!'));
-    const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1).trim());
+    const excludes = lines
+        .filter((l) => l.startsWith('!'))
+        .map((l) => l.slice(1).trim());
     const seen = new Set();
     const files = [];
     for (const pattern of includes) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -65485,6 +65485,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isDirectory = isDirectory;
 exports.findTestsToRun = findTestsToRun;
 const promises_1 = __nccwpck_require__(1455);
+const node_path_1 = __nccwpck_require__(6760);
 const fs = __importStar(__nccwpck_require__(2136));
 /**
  * Checks if a given path is a directory.
@@ -65508,10 +65509,22 @@ function isDirectory(filepath) {
  * @returns {Promise<string[]>} - A promise that resolves to an array of test file paths.
  */
 async function findTestsToRun(path) {
+    const lines = path
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+    const includes = lines.filter((l) => !l.startsWith('!'));
+    const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1));
+    const seen = new Set();
     const files = [];
-    for await (const file of (0, promises_1.glob)(path)) {
-        if (!isDirectory(file)) {
-            files.push(file);
+    for (const pattern of includes) {
+        for await (const file of (0, promises_1.glob)(pattern)) {
+            if (!seen.has(file) &&
+                !isDirectory(file) &&
+                !excludes.some((ex) => (0, node_path_1.matchesGlob)(file, ex))) {
+                seen.add(file);
+                files.push(file);
+            }
         }
     }
     return files;
@@ -65725,6 +65738,14 @@ module.exports = require("node:http2");
 
 "use strict";
 module.exports = require("node:net");
+
+/***/ }),
+
+/***/ 6760:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:path");
 
 /***/ }),
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,9 @@ export async function findTestsToRun(path: string): Promise<string[]> {
     .map((l) => l.trim())
     .filter((l) => l.length > 0)
   const includes = lines.filter((l) => !l.startsWith('!'))
-  const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1).trim())
+  const excludes = lines
+    .filter((l) => l.startsWith('!'))
+    .map((l) => l.slice(1).trim())
 
   const seen = new Set<string>()
   const files: string[] = []

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export async function findTestsToRun(path: string): Promise<string[]> {
     .map((l) => l.trim())
     .filter((l) => l.length > 0)
   const includes = lines.filter((l) => !l.startsWith('!'))
-  const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1))
+  const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1).trim())
 
   const seen = new Set<string>()
   const files: string[] = []

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { glob } from 'node:fs/promises'
+import { matchesGlob } from 'node:path'
 
 import * as fs from 'fs-extra'
 
@@ -24,10 +25,25 @@ export function isDirectory(filepath: string): boolean {
  * @returns {Promise<string[]>} - A promise that resolves to an array of test file paths.
  */
 export async function findTestsToRun(path: string): Promise<string[]> {
+  const lines = path
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+  const includes = lines.filter((l) => !l.startsWith('!'))
+  const excludes = lines.filter((l) => l.startsWith('!')).map((l) => l.slice(1))
+
+  const seen = new Set<string>()
   const files: string[] = []
-  for await (const file of glob(path)) {
-    if (!isDirectory(file)) {
-      files.push(file)
+  for (const pattern of includes) {
+    for await (const file of glob(pattern)) {
+      if (
+        !seen.has(file) &&
+        !isDirectory(file) &&
+        !excludes.some((ex) => matchesGlob(file, ex))
+      ) {
+        seen.add(file)
+        files.push(file)
+      }
     }
   }
   return files

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -96,5 +96,17 @@ describe('utils', () => {
       expect(testFiles).toContain(included2)
       expect(testFiles).not.toContain(excluded)
     })
+
+    it('should handle spaces after ! in negation patterns', async () => {
+      const included = path.join(tempDir, 'space-incl.js')
+      const excluded = path.join(tempDir, 'space-excl.js')
+      fs.writeFileSync(included, '')
+      fs.writeFileSync(excluded, '')
+
+      const pattern = `${tempDir}/space-*.js\n! ${excluded}`
+      const testFiles = await findTestsToRun(pattern)
+      expect(testFiles).toContain(included)
+      expect(testFiles).not.toContain(excluded)
+    })
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -81,5 +81,20 @@ describe('utils', () => {
       const testFiles = await findTestsToRun(`${tempDir}/subset*.js`)
       expect(testFiles).toEqual([testFile1, testFile2])
     })
+
+    it('should support multiline patterns with negation', async () => {
+      const included1 = path.join(tempDir, 'incl1.js')
+      const included2 = path.join(tempDir, 'incl2.js')
+      const excluded = path.join(tempDir, 'excl.js')
+      fs.writeFileSync(included1, '')
+      fs.writeFileSync(included2, '')
+      fs.writeFileSync(excluded, '')
+
+      const pattern = `${tempDir}/incl*.js\n${tempDir}/excl*.js\n!${excluded}`
+      const testFiles = await findTestsToRun(pattern)
+      expect(testFiles).toContain(included1)
+      expect(testFiles).toContain(included2)
+      expect(testFiles).not.toContain(excluded)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Regression fix for #146. The initial `node:fs/promises` replacement only handled single-pattern inputs. GitHub Actions inputs using the YAML `|` (pipe) syntax produce newline-separated strings like:

```
k6/examples/browser/*.js
!k6/examples/browser/hosts.js
!k6/examples/browser/throttle.js
```

`@actions/glob` supported this natively — newlines as pattern separators and `!` prefix as negation. The replacement broke this, causing `No test files found` in k6-cloud-browser-docker's `test-k6-browser-scripts` job.

## Fix

- Split input on newlines; route `!`-prefixed lines to an exclude list
- Use `path.matchesGlob` (Node 21.1+, stable in Node 22+) to filter excludes from each include pattern's results
- Deduplicate results across multiple include patterns

## Changes

- `src/utils.ts`: multiline + negation handling in `findTestsToRun`
- `test/utils.test.ts`: new test covering multiline patterns with negation
- `dist/index.js`: rebuilt

## Test plan

- [x] All 136 tests pass (`npm test`)
- [x] New test: `should support multiline patterns with negation`
- [x] `npm run package` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)